### PR TITLE
Fix v1.8 installation

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.2]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v1
@@ -20,10 +20,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # pip install wheel
     - name: Compile source code and install
       run: |
         python setup.py build
+        python setup.py sdist
         python setup.py install
     - name: Test with crc16.py
       run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include libscrc/test *.py
 recursive-include libscrc/_crc82.py
 recursive-include libscrc/plugins *.py
+graft src/**/


### PR DESCRIPTION
1. Adds path to headers to `MANIFEST.in` file
2. Fixes python versions in GitHub Actions
3. Build sdist in Actions

Should fix the compilation errors described here: https://github.com/hex-in/libscrc/issues/10#issuecomment-1212880036 but this has only tested on `3.10.6`