### PR TITLE
Update _crc16module.c

### DIFF
--- a/src/crc16/_crc16module.c
+++ b/src/crc16/_crc16module.c
@@ -788,7 +788,7 @@ static PyMethodDef _crc16Methods[] = {
     { "v41_lsb",     (PyCFunction)_crc16_kermit,    METH_VARARGS, "Calculate V-41-LSB of CRC16 [Poly=0x1021, Init=0x0000 Xorout=0x0000 Refin=True Refout=True]" },
     { "mcrf4xx",     (PyCFunction)_crc16_mcrf4xx,   METH_VARARGS, "Calculate MCRF4XX of CRC16 [Poly=0x1021, Init=0xFFFF Xorout=0x0000 Refin=True Refout=True]" },
     { "sick",        (PyCFunction)_crc16_sick,      METH_VARARGS, "Calculate SICK of CRC16 [Poly=0x8005, Init=0x0000]" },
-    { "dnp",         (PyCFunction)_crc16_dnp,       METH_VARARGS, "Calculate DNP (Ues:M-Bus, ICE870) of CRC16 [Poly=0x3D65, Init=0x0000 Xorout=0xFFFF Refin=False Refout=False]" },
+    { "dnp",         (PyCFunction)_crc16_dnp,       METH_VARARGS, "Calculate DNP (Ues:M-Bus, ICE870) of CRC16 [Poly=0x3D65, Init=0x0000 Xorout=0xFFFF Refin=True Refout=True]" },
     { "x25",         (PyCFunction)_crc16_x25,       METH_VARARGS, "Calculate X25 of CRC16 [Poly=0x1021, Init=0xFFFF Xorout=0xFFFF Refin=True Refout=True]" },
     { "ibm_sdlc",    (PyCFunction)_crc16_x25,       METH_VARARGS, "Calculate IBM-SDLC of CRC16 [Poly=0x1021, Init=0xFFFF Xorout=0xFFFF Refin=True Refout=True]" },
     { "iso_hdlc16",  (PyCFunction)_crc16_x25,       METH_VARARGS, "Calculate ISO-HDLC of CRC16 [Poly=0x1021, Init=0xFFFF Xorout=0xFFFF Refin=True Refout=True]" },


### PR DESCRIPTION
Thanks for your hard work. Your library helped me a lot and it much faster than my own C code :)

I spot a small error in the documentation for CRC-16/DNP.

According to this https://reveng.sourceforge.io/crc-catalogue/16.htm it should be Refin=True Refout=True. And it seems that libscrc.dnp already uses refin and refout.

```
import libscrc
import numpy as np

b1 = 0x82
b2 = 0xea

data = np.array([0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, b1, b2], np.uint8)

# width=16 poly=0x3d65 init=0x0000 refin=true refout=true xorout=0xffff check=0xea82 residue=0x66c5 name="CRC-16/DNP"
val1 = libscrc.dnp(data)
val2 = libscrc.hacker16(data, poly=0x3d65, init=0x0000, refin=True, refout=True, xorout=0xffff, reinit=False)

print((val1 ^ 0xffff) == 0x66c5) # is True
print(val1 == val2) # is True
```
